### PR TITLE
Fix flake8 'D' type errors

### DIFF
--- a/src/totp_calculator/main.py
+++ b/src/totp_calculator/main.py
@@ -1,6 +1,4 @@
-"""
-This module provides a command-line tool to calculate TOTP codes from URLs.
-"""
+"""Provides a command-line tool to calculate TOTP codes from URLs."""
 
 import argparse
 import re
@@ -36,8 +34,7 @@ SOFTWARE.
 
 
 def generate_totp(totp: pyotp.TOTP) -> str:
-    """
-    Generates a Time-Based One-Time Password (TOTP).
+    """Generate a Time-Based One-Time Password (TOTP).
 
     Args:
         totp: The TOTP object.
@@ -49,8 +46,7 @@ def generate_totp(totp: pyotp.TOTP) -> str:
 
 
 def find_totp_url(text: str) -> str:
-    """
-    Finds a TOTP URL in the given text.
+    """Find a TOTP URL in the given text.
 
     Args:
         text: The text to search for a TOTP URL.
@@ -70,8 +66,7 @@ def find_totp_url(text: str) -> str:
 
 
 def get_totp_from_url(url: str) -> pyotp.TOTP:
-    """
-    Parses a TOTP URL and returns a TOTP object.
+    """Parse a TOTP URL and returns a TOTP object.
 
     Args:
         url: The TOTP URL.
@@ -94,12 +89,12 @@ def get_totp_from_url(url: str) -> pyotp.TOTP:
 
 
 def read_stdin() -> str:
-    """Reads the entire content from stdin."""
+    """Read the entire content from stdin."""
     return sys.stdin.read()
 
 
 def main() -> None:
-    """The main entry point of the application."""
+    """Run the main entry point of the application."""
     parser = argparse.ArgumentParser(
         description=(
             "Scans for a TOTP URL from stdin, "

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,6 +1,4 @@
-"""
-Integration tests for the TOTP calculator.
-"""
+"""Integration tests for the TOTP calculator."""
 
 import io
 import runpy
@@ -102,9 +100,7 @@ def test_main_entry_point(
 @freeze_time(datetime(2023, 1, 1, 1, 1, 1, tzinfo=timezone.utc))
 @patch("sys.stdout", new_callable=io.StringIO)
 def test_main_with_all_non_default_params(mock_stdout: io.StringIO) -> None:
-    """
-    Test the main function with a TOTP URL that has all non-default parameters.
-    """
+    """Test the main function with a TOTP URL that has all non-default."""
     url = (
         "otpauth://totp/Test:user@example.com?secret=JBSWY3DPEHPK3PXP"
         "&issuer=Test&algorithm=SHA512&digits=7&period=45"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,4 @@
-"""
-Unit tests for the TOTP calculator.
-"""
+"""Unit tests for the TOTP calculator."""
 
 from unittest.mock import patch
 


### PR DESCRIPTION
This commit fixes all `flake8` errors of type 'D' (docstring related).

The following changes were made:
- `src/totp_calculator/main.py`:
  - Changed the module docstring to be a single line.
  - Changed function docstrings to start with an imperative verb.
- `tests/test_integration.py`:
  - Changed module and function docstrings to be single-line.
- `tests/test_main.py`:
  - Changed the module docstring to be a single line.

These changes ensure compliance with the pydocstyle checks enforced by flake8. No functional code was changed.