### PR TITLE
Fix flake8 "I" errors

### DIFF
--- a/src/totp_calculator/main.py
+++ b/src/totp_calculator/main.py
@@ -9,7 +9,6 @@ import sys
 import pyotp
 import pyperclip
 
-
 LICENSE_NOTICE = """
 MIT License
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -37,9 +37,7 @@ def test_main_no_url_error(mock_stderr: io.StringIO) -> None:
         assert "No TOTP URL found" in mock_stderr.getvalue()
 
 
-@patch(
-    "sys.stdin", io.StringIO("otpauth://totp/a?secret=1 otpauth://totp/b?secret=2")
-)
+@patch("sys.stdin", io.StringIO("otpauth://totp/a?secret=1 otpauth://totp/b?secret=2"))
 @patch("sys.stderr", new_callable=io.StringIO)
 def test_main_multiple_urls_error(mock_stderr: io.StringIO) -> None:
     """Test the main function when multiple URLs are provided."""
@@ -85,9 +83,7 @@ def test_main_copy_fail(
 @patch("sys.stdin", io.StringIO("otpauth://totp/test?secret=JBSWY3DPEHPK3PXP"))
 @patch("sys.stdout", new_callable=io.StringIO)
 @patch("pyotp.TOTP.now")
-def test_main_entry_point(
-    mock_now: MagicMock, mock_stdout: io.StringIO
-) -> None:
+def test_main_entry_point(mock_now: MagicMock, mock_stdout: io.StringIO) -> None:
     """Test the script's main entry point."""
     mock_now.return_value = "987654"
     with patch.object(sys, "argv", ["main.py"]):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -7,11 +7,8 @@ from unittest.mock import patch
 import pyotp
 import pytest
 
-from totp_calculator.main import (
-    find_totp_url,
-    generate_totp,
-    get_totp_from_url,
-)
+from totp_calculator.main import (find_totp_url, generate_totp,
+                                  get_totp_from_url)
 
 
 def test_generate_totp() -> None:
@@ -26,9 +23,7 @@ def test_generate_totp() -> None:
 def test_find_totp_url_single() -> None:
     """Test that a single TOTP URL is found correctly."""
     text = "Here is a TOTP URL: otpauth://totp/test?secret=JBSWY3DPEHPK3PXP"
-    assert (
-        find_totp_url(text) == "otpauth://totp/test?secret=JBSWY3DPEHPK3PXP"
-    )
+    assert find_totp_url(text) == "otpauth://totp/test?secret=JBSWY3DPEHPK3PXP"
 
 
 def test_find_totp_url_multiple() -> None:


### PR DESCRIPTION
This change fixes all the `isort` related errors (`I` errors) from `flake8`.

The import statements in `src/totp_calculator/main.py` and `tests/test_main.py` were reordered to comply with `isort` standards.